### PR TITLE
implemented tests for the isIsogram function

### DIFF
--- a/src/isIsogram.test.js
+++ b/src/isIsogram.test.js
@@ -6,4 +6,34 @@ describe('isIsogram', () => {
   it(`should be declared`, () => {
     expect(isIsogram).toBeInstanceOf(Function);
   });
+
+  it('word.length === 0 -> return: true', () => {
+    const result = isIsogram('');
+
+    expect(result).toBe(true);
+  });
+
+  it('word has letters only in LOWER case -> return: true', () => {
+    const result = isIsogram('shtonda');
+
+    expect(result).toBe(true);
+  });
+
+  it('word has letters only in UPPER case -> return: true', () => {
+    const result = isIsogram('SHTONDA');
+
+    expect(result).toBe(true);
+  });
+
+  it('word has 2 "D" letters -> return: false', () => {
+    const result = isIsogram('shtonda dev');
+
+    expect(result).toBe(false);
+  });
+
+  it('word has "D" and "d" letters -> return: false', () => {
+    const result = isIsogram('Shtonda Dev');
+
+    expect(result).toBe(false);
+  });
 });


### PR DESCRIPTION
In my opinion, this function should return **false**, if the **word** argument has any numbers or any special chars, because:

> Write a tests for the function isIsogram that takes a string word,
> that **contains only letters**, and checks whether this word is an isogram.

README.md has this text. So I think, that this function has incorrect implementation :(
